### PR TITLE
Provide a "who's been quoted the most" command.

### DIFF
--- a/src/quote.coffee
+++ b/src/quote.coffee
@@ -12,6 +12,7 @@
 #   hubot quote <query> - Retrieve a random quote that contains each word of <query>.
 #   hubot howmany <query> - Return the number of quotes that contain each word of <query>.
 #   hubot reload quotes - Reload the quote file.
+#   hubot quotestats - Show who's been quoted the most!
 #
 # Author:
 #   smashwilson


### PR DESCRIPTION
Fixes #6. I can't call it "quotestats" because that matches the "give me a quote" regexp.
